### PR TITLE
Fix build release apk issue, change compileSdkVersion to 28

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -25,7 +25,7 @@ apply plugin: 'com.android.library'
 apply plugin: 'kotlin-android'
 
 android {
-    compileSdkVersion 27
+    compileSdkVersion 28
 
     sourceSets {
         main.java.srcDirs += 'src/main/kotlin'

--- a/android/gradle.properties
+++ b/android/gradle.properties
@@ -1,1 +1,3 @@
 org.gradle.jvmargs=-Xmx1536M
+android.enableJetifier=true
+android.useAndroidX=true


### PR DESCRIPTION
solution
https://github.com/flutter/flutter/issues/27226#issuecomment-458574164

Error when build release apk
	FAILURE: Build failed with an exception.

	* What went wrong:
	Execution failed for task ':fzxing:verifyReleaseResources'.
	> java.util.concurrent.ExecutionException: com.android.builder.internal.aapt.v2.Aapt2Exception: Android resource linking failed
	  C:\Users\xxx\source\flutter\xxx\build\fzxing\intermediates\res\merged\release\values\values.xml:274: error: resource android:attr/fontVariationSettings not found.
	  C:\Users\xxx\source\flutter\xxx\build\fzxing\intermediates\res\merged\release\values\values.xml:275: error: resource android:attr/ttcIndex not found.
	  error: failed linking references.
